### PR TITLE
cudaのIDを外部から指定できるようにする

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -15,7 +15,6 @@ from model import BertForMultilabelNER, create_pooler_matrix
 
 import os
 
-device = "cuda:1" if torch.cuda.is_available() else "cpu"
 
 
 def ner_for_shinradata(model, tokenizer, shinra_dataset, device):
@@ -73,7 +72,7 @@ def parse_arg():
     parser.add_argument("--input_path", type=str, help="Specify input path in SHINRA2020")
     parser.add_argument("--model_path", type=str, help="Specify attribute_list path in SHINRA2020")
     parser.add_argument("--output_path", type=str, help="Specify attribute_list path in SHINRA2020")
-
+    parser.add_argument("--cuda", type=int, help="Specify attribute_list path in SHINRA2020")
     args = parser.parse_args()
 
     return args
@@ -81,6 +80,11 @@ def parse_arg():
 
 if __name__ == "__main__":
     args = parse_arg()
+
+    if torch.cuda.is_available():
+        device = f"cuda:{args.cuda}"
+    else:
+        device = "cpu"
 
     bert = AutoModel.from_pretrained("cl-tohoku/bert-base-japanese")
     tokenizer = AutoTokenizer.from_pretrained("cl-tohoku/bert-base-japanese")

--- a/src/predict.sh
+++ b/src/predict.sh
@@ -1,4 +1,5 @@
 python predict.py \
     --input_path /path/to/Target_Category \
     --model_path /path/to/model_file \
-    --output_path /path/to/output_file
+    --output_path /path/to/output_file \
+    --cuda 0 \

--- a/src/train.py
+++ b/src/train.py
@@ -19,7 +19,6 @@ from dataset import NerDataset, ner_collate_fn, decode_iob
 from model import BertForMultilabelNER, create_pooler_matrix
 from predict import predict
 
-device = "cuda:2" if torch.cuda.is_available() else "cpu"
 
 
 class EarlyStopping():
@@ -54,6 +53,7 @@ def parse_arg():
     parser.add_argument("--grad_acc", type=int, help="Specify attribute_list path in SHINRA2020")
     parser.add_argument("--grad_clip", type=float, help="Specify attribute_list path in SHINRA2020")
     parser.add_argument("--seed", type=int, help="Specify attribute_list path in SHINRA2020")
+    parser.add_argument("--cuda", type=int, help="Specify attribute_list path in SHINRA2020")
     parser.add_argument("--note", type=str, help="Specify attribute_list path in SHINRA2020")
 
     args = parser.parse_args()
@@ -135,6 +135,11 @@ def train(model, train_dataset, valid_dataset, attributes, args):
 
 if __name__ == "__main__":
     args = parse_arg()
+
+    if torch.cuda.is_available():
+        device = f"cuda:{args.cuda}"
+    else:
+        device = "cpu"
 
     set_seed(args.seed)
 

--- a/src/train.sh
+++ b/src/train.sh
@@ -6,3 +6,5 @@ python train.py \
     --epoch 50 \
     --grad_acc 1 \
     --grad_clip 1.0 \
+    --seed 0 \
+    --cuda 0 \


### PR DESCRIPTION
colabなどを使って学習する際に、cuda:2やcuda:1を修正する必要があったので外部から設定できるように修正しました

train.shにseedの変更が反映されていないようだったので追加しました